### PR TITLE
Fix baseURL mismatch causing Netlify 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Official API reference, integration guides, and CLI documentation for the **Recuerdo** platform — a multi-tenant media management system built with Go microservices.
 
-**Live site**: https://recuerdo-developers-docs.netlify.app/
+**Live site**: https://recerdo-developers-docs.netlify.app/
 
 ## Tech Stack
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://recuerdo-developers-docs.netlify.app/"
+baseURL = "https://recerdo-developers-docs.netlify.app/"
 title = "Recuerdo Developer Docs"
 languageCode = "en"
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,5 +1,5 @@
 # Recuerdo API - Developer Documentation
-# https://recuerdo-developers-docs.netlify.app
+# https://recerdo-developers-docs.netlify.app
 #
 # This file helps AI assistants and LLM tools understand the available documentation.
 # Format: llms.txt v1 (https://llmstxt.org)
@@ -12,22 +12,22 @@ album management, and API telemetry.
 ## Documentation Pages
 
 > Getting Started
-- [Introduction & Quick Start](https://recuerdo-developers-docs.netlify.app/guide/getting-started): Base URL, first API call, request headers, org_id usage
-- [Authentication](https://recuerdo-developers-docs.netlify.app/guide/authentication): JWT tokens, AWS Cognito, token refresh, user roles
-- [Media Upload](https://recuerdo-developers-docs.netlify.app/guide/media-upload): Standard upload, chunked upload, HEIC conversion, delivery options
+- [Introduction & Quick Start](https://recerdo-developers-docs.netlify.app/guide/getting-started): Base URL, first API call, request headers, org_id usage
+- [Authentication](https://recerdo-developers-docs.netlify.app/guide/authentication): JWT tokens, AWS Cognito, token refresh, user roles
+- [Media Upload](https://recerdo-developers-docs.netlify.app/guide/media-upload): Standard upload, chunked upload, HEIC conversion, delivery options
 
 > API Reference
-- [Architecture Overview](https://recuerdo-developers-docs.netlify.app/api/overview): Microservices diagram, service ports, multi-tenancy, tech stack
-- [Auth Service](https://recuerdo-developers-docs.netlify.app/api/auth): Login, logout, token refresh, Cognito sync endpoints
-- [Core Service](https://recuerdo-developers-docs.netlify.app/api/core): Users, organizations, events, invitations, timeline endpoints
-- [Storage Service](https://recuerdo-developers-docs.netlify.app/api/storage): Media upload, chunked upload, delivery with type parameter
-- [Album Service](https://recuerdo-developers-docs.netlify.app/api/album): Album listing, event album with cover/highlight/media
-- [Metrics Service](https://recuerdo-developers-docs.netlify.app/api/metrics): Access logs, API telemetry (admin only)
-- [Interactive API Explorer](https://recuerdo-developers-docs.netlify.app/api/explorer): Swagger UI with service filter tabs
+- [Architecture Overview](https://recerdo-developers-docs.netlify.app/api/overview): Microservices diagram, service ports, multi-tenancy, tech stack
+- [Auth Service](https://recerdo-developers-docs.netlify.app/api/auth): Login, logout, token refresh, Cognito sync endpoints
+- [Core Service](https://recerdo-developers-docs.netlify.app/api/core): Users, organizations, events, invitations, timeline endpoints
+- [Storage Service](https://recerdo-developers-docs.netlify.app/api/storage): Media upload, chunked upload, delivery with type parameter
+- [Album Service](https://recerdo-developers-docs.netlify.app/api/album): Album listing, event album with cover/highlight/media
+- [Metrics Service](https://recerdo-developers-docs.netlify.app/api/metrics): Access logs, API telemetry (admin only)
+- [Interactive API Explorer](https://recerdo-developers-docs.netlify.app/api/explorer): Swagger UI with service filter tabs
 
 > Admin CLI
-- [CLI Overview](https://recuerdo-developers-docs.netlify.app/cli/overview): Installation, commands (init/add/remove/list/status/validate)
-- [RSP v1 Protocol](https://recuerdo-developers-docs.netlify.app/cli/rsp-protocol): Service manifest schema, health check spec, registry format
+- [CLI Overview](https://recerdo-developers-docs.netlify.app/cli/overview): Installation, commands (init/add/remove/list/status/validate)
+- [RSP v1 Protocol](https://recerdo-developers-docs.netlify.app/cli/rsp-protocol): Service manifest schema, health check spec, registry format
 
 ## OpenAPI Specification
 


### PR DESCRIPTION
## Summary

Fixes the "Site not found" 404 error on Netlify caused by a URL mismatch between Hugo's `baseURL` and the actual Netlify site name.

## Root cause

- Hugo `baseURL` was set to `recuerdo-developers-docs` (with 'u')
- Netlify site name is `recerdo-developers-docs` (without 'u')
- This caused sitemap, canonical URLs, and links to point to a non-existent domain

## Changes

- `hugo.toml`: Fix baseURL to `https://recerdo-developers-docs.netlify.app/`
- `README.md`: Fix live site link
- `static/llms.txt`: Fix all 13 documentation page URLs

## Test plan

- [ ] Verify site loads at https://recerdo-developers-docs.netlify.app/
- [ ] Verify sitemap URLs are correct
- [ ] Verify llms.txt links resolve

https://claude.ai/code/session_01YNcmA1bwN7xJCUyxym9shc