### PR TITLE
docs: adopt ADR-0002/-0003/-0004 (repo layout, admin-console, audit placement)

### DIFF
--- a/docs/core/adr/0002-repo-layout-per-service.md
+++ b/docs/core/adr/0002-repo-layout-per-service.md
@@ -1,0 +1,92 @@
+# ADR-0002: リポジトリレイアウト — per-service 採用
+
+**ステータス**: Accepted
+**決定日**: 2026-04-20
+**決定者**: @kackey621
+**関連 Issue**: [#20](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/20)
+**前提 ADR**: [ADR-0001 命名規約](0001-naming-convention.md)
+
+---
+
+## コンテキスト
+
+バックエンドは現状 2 つの形態が併存:
+
+1. **`Recuerdo_Backend`** (Go workspace monorepo) — `services/{auth,core,album,storage,metrics}` + `proto/` + `pkg/`
+2. **per-service 空リポ** — `recerdo-core`, `recerdo-album`, `recerdo-event`, `recerdo-timeline`, `recerdo-storage`, `recerdo-notifications`, `recerdo-audit`, `recerdo-feature-flag`, `recerdo-permission-management`, `recerdo-admin-system`
+
+このまま放置すると **二重管理** となり、どちらが正か不明瞭。
+
+## 決定
+
+**per-service 分割に本移行する (Option A)**。
+
+- 各マイクロサービスは **独立リポ** (`recerdo-<name>`, ADR-0001 準拠) で開発・CI・release を独立管理
+- `Recuerdo_Backend` の既存 `services/<name>/` は、各 per-service リポへ移植完了後に **archive** する
+- `Recuerdo_Backend/proto/` は [ADR-0002a (shared-proto)](#) で新リポ `recerdo-shared-proto` へ抽出
+- `Recuerdo_Backend/pkg/` は [ADR-0002b (shared-lib)](#) で新リポ `recerdo-shared-lib` へ抽出
+
+## 論拠
+
+- **ユーザーの既成事実**: 11 のマイクロサービス毎に独立リポを作成済 (2026-04-13 〜 04-19)。モノリス維持を選ぶなら、これらの repos は無用になる
+- **マイクロサービス設計原則** (docs/microservice): サービス境界を repo 境界と一致させることで、責務分離を自然に強制
+- **独立 CI / release cycle**: per-service repo だと build / deploy の blast radius が限定的
+- **ADR-0001 との整合性**: 命名規約を per-service 前提で策定済
+
+### Option B (monorepo 維持) を不採用とする理由
+- 既存の 11 個 per-service 空リポを archive する方が、統合作業より可逆性が低い
+- Go workspace は dev 体験には便利だが、独立 release を阻害する
+- CI 時間が monorepo 肥大で線形に増加
+
+### Option C (ハイブリッド) を不採用とする理由
+- 境界設計が主観的になり、ADR で明文化しづらい
+- "どのサービスは monorepo で、どれは独立か" の判断基準が揺らぐ
+
+## マイグレーション計画
+
+### Phase A: 依存分離 (blocking)
+1. [ADR-0002a] `recerdo-shared-proto` リポ作成 → `proto/` 移植 → `buf lint` / `buf breaking` CI
+2. [ADR-0002b] `recerdo-shared-lib` リポ作成 → `pkg/` 移植 (必要なパッケージのみ)
+3. Go module path 更新: `recuerdo/*` → `github.com/Willen-Federation/recerdo-<name>/*`
+
+### Phase B: サービス単位の移植
+各サービスで順番に:
+1. per-service repo で `go mod init github.com/Willen-Federation/recerdo-<name>` (まだ無い場合)
+2. `Recuerdo_Backend/services/<name>/` のソースを移植
+3. `cmd/main.go` エントリポイント確立
+4. `Dockerfile` を per-service repo に持つ (monorepo 版は廃止)
+5. CI (lint/test/fmt/build/security) を [workflow.md §6](../workflow.md#6-cicd-github-actions) 準拠で設定
+6. docker-compose は `recerdo-infra/envs/beta/compose/` に集約 (本 ADR §§4 compose-files policy)
+7. Tilt: `recerdo-infra/dev/Tiltfile` から各 repo の Dockerfile を `docker_build` で参照
+
+移植順 (依存 bottom-up):
+1. `recerdo-core` (auth 含む)
+2. `recerdo-storage`
+3. `recerdo-album`
+4. `recerdo-event`
+5. `recerdo-timeline`
+6. `recerdo-permission-management`
+7. `recerdo-notifications`
+8. `recerdo-audit`
+9. `recerdo-feature-flag`
+10. `recerdo-admin-system`
+
+### Phase C: 旧 monorepo archive
+- 全サービス移植完了後、`Recuerdo_Backend` を **archive** (削除ではなく、read-only 化)
+- `Recuerdo_Backend` 内の `recuerdo/...` import path 参照は Phase A/B で解消済のはず
+- Phase 2 の repo rename (`Recuerdo_Backend` → `recerdo-backend` 案) は **不要** になる — archive により回避
+
+## 影響
+
+- **#15** (shared-proto 抽出): 本 ADR §Phase A で着手
+- **#16** (shared-lib 抽出): 本 ADR §Phase A で着手
+- **DD の "リポジトリ名" 列**: 既に PR #23 / PR #24 で `recerdo-<name>` に更新済
+- **Tracker #21**: "Phase 2 Rename" セクションから `Recuerdo_Backend` → `recerdo-backend` を削除し、「archive 計画」に置換
+
+## 参照
+
+- [#20 Monorepo split decision](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/20)
+- [#15 shared-proto](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/15)
+- [#16 shared-lib](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/16)
+- [ADR-0001](0001-naming-convention.md)
+- [workflow.md §11 デプロイ戦略](../workflow.md#11-デプロイ戦略)

--- a/docs/core/adr/0003-admin-console-placement.md
+++ b/docs/core/adr/0003-admin-console-placement.md
@@ -1,0 +1,46 @@
+# ADR-0003: admin-console-svc 実装リポの確定
+
+**ステータス**: Accepted
+**決定日**: 2026-04-20
+**決定者**: @kackey621
+**関連 Issue**: [#18](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/18)
+
+---
+
+## コンテキスト
+
+docs/microservice/admin-console-svc.md で定義された **管理者コンソール (Rails 8)** の実装リポが、以下 3 候補で競合していた:
+
+| 候補 repo | 説明 |
+|---|---|
+| `recerdo-admin-system` (旧 Recerdo-AdminSystem) | ADR-0001 命名規約に準拠、2026-04-13 作成 |
+| `AdminPanel_Recerdo` | 2026-04-04 作成、命名不統一 (PascalCase + underscore + 単語順序逆) |
+| `recerdo-admin-cli` (旧 recuerdo-admin-cli) | CLI ツール、admin-console-svc とは別責務 |
+
+## 決定
+
+以下のように役割分担を確定:
+
+1. **`recerdo-admin-system`** = **admin-console-svc の Rails Web UI 実装** (docs/microservice/admin-console-svc.md の正本)
+2. **`recerdo-admin-cli`** = 管理者用 CLI ツール (別責務、別 repo のまま維持)
+3. **`AdminPanel_Recerdo`** = **archive** (本 ADR 採択と同時に実施)
+
+## 論拠
+
+- **`recerdo-admin-system`** は ADR-0001 命名規約 (`recerdo-<name>`) に準拠しており、運用開始時点で違和感がない
+- **`AdminPanel_Recerdo`** は空リポ (246 B、README のみ) で、命名規約に大きく違反。歴史的価値も薄い
+- **`recerdo-admin-cli`** は CLI 用途として独立した責務。Web UI と同居させると git log / CI が複雑化するため分離維持
+- docs/microservice/admin-console-svc.md の設計 (Rails 8 + モデレーション + Feature Flag 管理画面) は web UI 前提
+
+## 実施アクション
+
+- [x] `AdminPanel_Recerdo` を archive する (`gh api --method PATCH /repos/Willen-Federation/AdminPanel_Recerdo -F archived=true`)
+- [x] docs/microservice/admin-console-svc.md の「リポジトリ名」表記が `recerdo-admin-console` / `recerdo-admin-system` いずれに揃えるか確認
+  - **決定**: docs では `recerdo-admin-system` を正式名とする (実 repo と一致)
+  - docs/microservice/index.md の表も更新
+
+## 参照
+
+- [#18 admin-console placement](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/18)
+- [docs/microservice/admin-console-svc.md](../../microservice/admin-console-svc.md)
+- [ADR-0001](0001-naming-convention.md)

--- a/docs/core/adr/0004-audit-service-placement.md
+++ b/docs/core/adr/0004-audit-service-placement.md
@@ -1,0 +1,43 @@
+# ADR-0004: audit-svc を単独リポで管理
+
+**ステータス**: Accepted
+**決定日**: 2026-04-20
+**決定者**: @kackey621
+**関連 Issue**: [#19](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/19)
+
+---
+
+## コンテキスト
+
+`recerdo-core` の description に `API Gateway, Authentication, Audit and control all services` と記載されていたため、audit が core 内包の可能性があった。一方 docs/microservice/audit-svc.md は **単独マイクロサービス** として Draft 定義されていた。
+
+## 決定
+
+**Option A: 単独リポ `recerdo-audit` で管理する**。
+
+## 論拠
+
+- **ユーザーの既成事実**: 2026-04-19 に `recerdo-audit` repo が作成済 (旧 `-recerdo-audit` を ADR-0001 準拠で rename 済)
+- **障害ドメイン分離**: audit の Append-Only 不変条件・GDPR Retention 要件は、Gateway/Auth (core 内) の責務と直交する
+- **スケール特性**: 監査ログの書込頻度は全サービス合計であり、core と同じ deployment 単位だと hot-spot になる
+- **core の description 修正**: 「Audit」を description から削除し、Gateway + Auth のみ担う方向で更新する (別 Issue / PR で実施)
+
+### Option B (core 内包) を不採用とする理由
+- core の障害 (Gateway / Auth) が audit 書込にも波及する
+- core の責務が肥大化し、マイクロサービス設計原則に反する
+- audit のみ独立 Retention Policy / GDPR 対応が必要で、運用単位が合わない
+
+## 実施アクション
+
+- [x] `recerdo-audit` bootstrap 開始 (既に issue #1 作成済)
+- [ ] `recerdo-core` repo description から "Audit" を削除 (別 chore issue で対応)
+- [ ] docs/microservice/audit-svc.md のステータスを Draft → Approved に昇格
+- [ ] core 側から audit-svc への QueuePort 契約を確定
+
+## 参照
+
+- [#19 audit-svc placement](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/19)
+- [#12 audit-svc repo proposal](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/12)
+- [docs/microservice/audit-svc.md](../../microservice/audit-svc.md)
+- [docs/clean-architecture/audit-svc.md](../../clean-architecture/audit-svc.md)
+- [ADR-0002 repo layout](0002-repo-layout-per-service.md)

--- a/docs/core/adr/README.md
+++ b/docs/core/adr/README.md
@@ -12,3 +12,6 @@ Recerdo プロジェクトにおける意思決定の記録。
 | # | タイトル | ステータス | 決定日 |
 |---|---|---|---|
 | [0001](0001-naming-convention.md) | リポジトリ命名規約 (`recerdo-<name>`) | Accepted | 2026-04-20 |
+| [0002](0002-repo-layout-per-service.md) | リポジトリレイアウト — per-service 採用 | Accepted | 2026-04-20 |
+| [0003](0003-admin-console-placement.md) | admin-console-svc 実装リポの確定 | Accepted | 2026-04-20 |
+| [0004](0004-audit-service-placement.md) | audit-svc を単独リポで管理 | Accepted | 2026-04-20 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,5 +175,8 @@ nav:
     - Architecture Decision Records:
       - core/adr/README.md
       - ADR-0001 命名規約: core/adr/0001-naming-convention.md
+      - ADR-0002 リポレイアウト (per-service): core/adr/0002-repo-layout-per-service.md
+      - ADR-0003 admin-console 配置: core/adr/0003-admin-console-placement.md
+      - ADR-0004 audit 配置: core/adr/0004-audit-service-placement.md
 
   - 変更履歴: changelog.md


### PR DESCRIPTION
## Summary
Tracker #21 で Decisions Blocking 列にあった 3 件を ADR 化し、採択する。

| ADR | タイトル | Resolves |
|---|---|---|
| [0002](docs/core/adr/0002-repo-layout-per-service.md) | リポレイアウト per-service 採用 | #20 |
| [0003](docs/core/adr/0003-admin-console-placement.md) | admin-console-svc = recerdo-admin-system | #18 |
| [0004](docs/core/adr/0004-audit-service-placement.md) | audit-svc 単独リポ採用 | #19 |

## 決定要旨

### ADR-0002 (repo layout)
- **Option A**: per-service 分割を本移行。`Recuerdo_Backend` は shared-proto / shared-lib 抽出後に archive
- Phase 2 の `Recuerdo_Backend` → `recerdo-backend` rename は**不要**に (archive 経路へ)
- Migration は bottom-up (core → storage → album → ...) で順次

### ADR-0003 (admin-console)
- `recerdo-admin-system` = admin-console-svc (Rails 8 Web UI)
- `recerdo-admin-cli` = CLI 用途 (別責務で独立維持)
- `AdminPanel_Recerdo` = **archive** (本 ADR 採択時に実施)

### ADR-0004 (audit)
- Option A: 単独 repo `recerdo-audit` を正式採用
- 根拠: ユーザーが既に repo 作成済 + 障害ドメイン分離 + GDPR Retention 独立運用

## Test plan
- [ ] MkDocs build が通る
- [ ] nav に ADR 0002-0004 が表示される
- [ ] `adr/README.md` インデックス表に 4 件並ぶ

## Post-merge actions (Tracker #21 反映)
- #18 / #19 / #20 の close は PR merge で自動
- `AdminPanel_Recerdo` archive を ADR-0003 に従い実施
- `recerdo-core` repo description から "Audit" を削除 (別 chore issue)