### PR TITLE
docs: enforce TDD Red-Green-Refactor process (#41)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,53 +1,313 @@
 # Recerdo Platform AI Coding Context (CLAUDE.md)
 
+> **版**: v2.0 (2026-04-22) — オーケストレーター決定 (2026-04-20) 反映済み  
+> **適用**: Claude Code / GitHub Copilot 等の AI コーディングアシスタント全般
+
+---
+
 ## 1. 役割とミッション
+
 あなたは Recerdo プラットフォームのシニア・フルスタックエンジニアです。本ドキュメントは、AIコーディングアシスタントが各リポジトリを理解し、一貫したアーキテクチャとセキュリティ基準を満たすコードを生成するための共通ルール（エージェントコンテキスト）を定義します。
 
-## 2. アーキテクチャ原則
-- **クリーンアーキテクチャ**: 全てのバックエンドサービスは Clean Architecture（Port / Adapter パターン）に従うこと。
-- **命名規則**:
-  - Port名は抽象化された役割に基づき命名すること（例: `AuthPort`, `CachePort`, `StoragePort`, `QueuePort`, `MailPort`）。
-- **技術スタック**:
-  - 言語: Go 1.24
-  - フレームワーク: Gin
-  - ORM: GORM
-  - DB: MySQL 8.0（MariaDB 10.6 互換必須）
+**全ての生成コードはこのドキュメントのルールに従うこと。例外は認めない。**
 
-## 3. 禁止事項・禁止キーワード
-特定クラウドプロバイダやミドルウェアに依存した命名や実装は禁止します。
-- **禁止キーワード**: `S3Port`, `SQSPort`, `SESPort`, `MinIOPort`, `DynamoDBPort` 等、特定製品名を冠した Port 命名。
-- アダプター層（Adapter）以外での特定インフラSDKの直接呼び出し。
+---
+
+## 2. アーキテクチャ原則
+
+### 2.1 クリーンアーキテクチャ (Port / Adapter パターン)
+
+全てのバックエンドサービスは Clean Architecture に従うこと:
+
+```
+domain/       ← ビジネスロジック・エンティティ (依存なし)
+application/  ← ユースケース (domain のみ依存)
+adapter/      ← 外部システム実装 (application の Port を実装)
+infra/        ← サーバー起動・DI (全層を組み合わせる)
+```
+
+### 2.2 命名規則
+
+**Port 名**（抽象化された役割）:
+- ✅ `StoragePort`, `QueuePort`, `MailPort`, `CachePort`, `AuthPort`
+- ✅ `FeatureFlagPort`, `AuditEventPort`, `MediaTranscoderPort`
+- ❌ `S3Port`, `SQSPort`, `SESPort`, `MinIOPort`, `DynamoDBPort` — **禁止**
+
+**Adapter 名**:
+- Storage: `GarageStorageAdapter` / `OCIObjectStorageAdapter`
+- Queue: `RedisBullMQAdapter` / `AsynqAdapter` / `OCIQueueAdapter`
+- Mail: `PostfixSMTPAdapter`
+- Auth: `CognitoAuthAdapter`
+
+**ファイル命名**: Go は `snake_case.go`, TypeScript は `camelCase.ts`
+
+### 2.3 技術スタック (確定版 2026-04-22)
+
+| 領域 | スタック | 備考 |
+|---|---|---|
+| バックエンド | Go 1.24 + Gin + GORM | |
+| DB (Beta) | MySQL 8.0 | **MariaDB 10.11 互換必須** ← 10.6 から更新 |
+| DB (Prod) | OCI MySQL HeatWave | MariaDB 10.11 互換維持 |
+| スキーマ変更 | **gh-ost** (Zero-downtime) | Flyway/Liquibase は軽微変更のみ |
+| キャッシュ | Redis 7.x | |
+| キュー (Beta) | Redis + asynq (Go) / BullMQ (Node) | |
+| キュー (Prod) | OCI Queue Service (AMQP 1.0) | Feature Flag で切替 |
+| 認証 | AWS Cognito + JWKS (RS256) | |
+| Feature Flag | Flipt + OpenFeature | |
+| SPA Frontend | **Next.js 15 + shadcn/ui** (Phase1) | |
+| Admin Console | **Next.js 15 + shadcn/ui** (Phase1) | **Rails は Phase3** |
+| iOS | Swift 5 + SwiftUI | |
+| Android | **Kotlin + Jetpack Compose** | ← Flutter から変更 |
+| Desktop | Electron + TypeScript | |
+
+---
+
+## 3. 禁止事項
+
+### 3.1 禁止キーワード (コード・設定・環境変数)
+
+```
+# AWS は Cognito 以外全て禁止
+S3Adapter / S3Port / S3StorageAdapter
+SQSAdapter / SQSPort
+SESAdapter / SESEmailAdapter
+DynamoDBAdapter / DynamoDBPort
+RDSAdapter / ElastiCacheAdapter
+MinioAdapter / MinIOPort
+
+# 環境変数での禁止値
+STORAGE_PROVIDER=aws-s3
+QUEUE_PROVIDER=aws-sqs
+MAIL_PROVIDER=aws-ses
+```
+
+### 3.2 コーディング禁止パターン
+
+- `if env == "production"` / `if os.Getenv("APP_ENV") == "production"` — 環境名分岐は禁止
+  → Feature Flag (`flipt.EvaluateFlag`) で切替ること
+- SQL 文字列結合 (`"WHERE id = " + id`) — Prepared Statement / GORM を使うこと
+- PII をログに出力すること (`email`, `phone_number`, `password`, `full_name`)
+- 空のテスト関数 (`func TestXxx(t *testing.T) {}`) — TDD 必須
+- `t.Skip()` / `it.skip()` の無条件使用 — 理由なきスキップ禁止
+
+### 3.3 admin-system フロントエンド禁止
+
+**Phase1 の `recerdo-admin-system` では Rails コードを生成してはならない。**  
+Phase1 は必ず Next.js 15 + shadcn/ui + TypeScript を使用すること。  
+Rails の追加は `[Stage1-Phase3] Rails 8 Admin Bundle` Issue で明示指示がある場合のみ。
+
+---
 
 ## 4. 必須実装パターン
-分散システムにおける信頼性と整合性を担保するため、以下のパターンを必須とします。
-- **Idempotency Key（冪等性キー）**: 全ての更新系（POST/PUT/PATCH/DELETE）APIエンドポイントで冪等性を保証すること。
-- **Transactional Outbox パターン**: データベース更新とイベント発行（Queue送信など）を同一トランザクションで確実に実行すること。
-- **Circuit Breaker（サーキットブレーカー）**: 外部サービスや他マイクロサービス呼び出し時に障害の連鎖を防ぐこと。
 
-## 5. テスト要件
-- **カバレッジ**: ユニットテストカバレッジ `go test -cover ≥ 80%` を維持すること。
-- **DB互換性**: 全てのGORMモデル・マイグレーションは、MySQL 8.0 および MariaDB 10.6 互換性 CI Matrix でパスすること。
+### 4.1 Idempotency Key（冪等性）
+
+全ての更新系 API (`POST` / `PUT` / `PATCH` / `DELETE`) で必須:
+
+```go
+// リクエストヘッダから取得
+idempotencyKey := r.Header.Get("Idempotency-Key")
+if idempotencyKey == "" {
+    return nil, ErrMissingIdempotencyKey
+}
+
+// Redis で処理済みチェック
+cached, err := cache.Get(ctx, "idempotency:"+idempotencyKey)
+if err == nil && cached != "" {
+    return unmarshalCachedResponse(cached), nil
+}
+```
+
+### 4.2 Transactional Outbox パターン
+
+DB 更新とイベント発行の原子性を保証する:
+
+```go
+// トランザクション内で DB 更新と Outbox 挿入を同時に実行
+tx.Create(&entity)
+tx.Create(&OutboxEvent{
+    AggregateID: entity.ID,
+    EventType:   "album.created",
+    Payload:     marshalPayload(entity),
+})
+// → Outbox Worker が非同期でキューに送信
+```
+
+### 4.3 Circuit Breaker
+
+外部サービス呼び出し時に障害の連鎖を防ぐ:
+
+```go
+// sony/gobreaker または go-resilience/breaker を使用
+cb := gobreaker.NewCircuitBreaker(gobreaker.Settings{
+    MaxRequests: 5,
+    Interval:    30 * time.Second,
+    Timeout:     60 * time.Second,
+})
+result, err := cb.Execute(func() (interface{}, error) {
+    return externalService.Call(ctx, input)
+})
+```
+
+---
+
+## 5. TDD 必須義務 (AI エージェント向け最重要ルール)
+
+> **出典**: [tdd-process.md](core/tdd-process.md), Issue #41
+
+### 5.1 Red-Green-Refactor の厳守
+
+**AIエージェントは以下の順序で必ず実施すること:**
+
+1. **先行テスト実装** → テストを書いてから実装コードを書く
+2. **Red 確認** → `go test ./...` で `FAIL` を確認・GitHub Actions URL を記録
+3. **実装** → テストを通過させる最小限の実装
+4. **Green 確認** → `PASS` + カバレッジを確認・GitHub Actions URL を記録
+5. **PR 提出** → Red log + Green log + Coverage を PR body に添付
+
+### 5.2 PR body 必須項目
+
+```markdown
+## TDD 証跡（必須）
+
+### Red log（修正前: 失敗確認）
+<details><summary>失敗ログを貼付</summary>
+（FAIL ログまたは N/A - 新規実装）
+</details>
+
+### Green log（修正後: 成功確認）
+<details><summary>成功ログを貼付</summary>
+（PASS + カバレッジ値）
+</details>
+
+### Coverage
+- Line coverage: __%（閾値: ≥ 80%）
+- Branch coverage: __%（閾値: ≥ 70%）
+```
+
+### 5.3 カバレッジ閾値
+
+| 言語 | Line Coverage | Branch Coverage |
+|---|---|---|
+| Go | **≥ 80%** | **≥ 70%** |
+| TypeScript | **≥ 80%** | **≥ 70%** |
+| Swift | **≥ 80%** | — |
+| Kotlin | **≥ 80%** | **≥ 70%** |
+
+### 5.4 禁止行為
+
+- Red ログなしで「テスト済み」と主張すること
+- `t.Skip()` / `it.skip()` を理由なく使用すること
+- 空のテスト関数を含む PR を提出すること
+- カバレッジ水増しのために意味のない assertion を追加すること (`assert(true)` 等)
+
+---
 
 ## 6. セキュリティ要件
-- **認証**: 全ての非公開APIで JWT トークン検証（AWS Cognito JWKS 対応）ミドルウェアを適用すること。
-- **ログ**: ユーザー名、メールアドレス、パスワード等の PII (Personally Identifiable Information) はログに絶対出力しないこと。
-- **通信**: メール送信等の外部通信において STARTTLS 等による暗号化を強制すること。
 
-## 7. バイブコーディング委譲可能タスク vs 手動レビュー必須タスク
-### AIに委譲可能（バイブコーディング適性：高）
+### 6.1 認証・認可
+
+- 全ての非公開 API で JWT トークン検証（AWS Cognito JWKS / RS256）ミドルウェアを適用すること
+- JWT の `alg` フィールドが RS256 であることを検証すること (`alg: none` 攻撃対策)
+- リソースへのアクセスは `owner_id` と認証ユーザーの ID を必ず比較すること (IDOR 対策)
+- JWT 保存戦略: Cognito Hosted UI の制約により **localStorage** を基本方針とする
+
+### 6.2 PII 保護
+
+- ログにメールアドレス・電話番号・パスワード・フルネームを**絶対に出力しない**こと
+- API レスポンスに不要な PII を含めないこと
+- エラーメッセージに内部実装詳細を含めないこと
+
+### 6.3 Trojan Source 攻撃防止
+
+ソースコードに以下の文字を混入させてはならない:
+- BiDi 制御文字 (U+202A-U+202E, U+2066-U+2069)
+- Zero Width Space (U+200B), Zero Width Joiner (U+200D)
+
+### 6.4 通信
+
+- 全外部通信で TLS 1.2+ を強制すること
+- Postfix SMTP は STARTTLS (`smtpd_tls_security_level=encrypt`) を必須とすること
+
+---
+
+## 7. MariaDB 10.11 互換性要件
+
+全てのマイグレーションと GORM モデルは MySQL 8.0 + **MariaDB 10.11** 両方でテストすること。
+
+**利用可能な機能**: `WINDOW 関数`, `CTE`, `JSON 型`, `GENERATED COLUMN`, `CHECK 制約`  
+**利用禁止** (MySQL 固有): `JSON_TABLE`, `SELECT ... FOR UPDATE SKIP LOCKED`
+
+CI テスト設定:
+```yaml
+services:
+  mariadb:
+    image: mariadb:10.11
+    env:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: recerdo_test
+```
+
+---
+
+## 8. バイブコーディング委譲可能 vs 手動レビュー必須
+
+### AI に委譲可能（適性：高）
 - REST API エンドポイントの実装
-- GORM モデル定義・マイグレーション（MariaDB 互換チェック付き）
+- GORM モデル定義・マイグレーション（MariaDB 10.11 互換チェック付き）
 - バリデーションロジック
-- 単体テストの生成
+- 単体テスト生成（TDD 義務に従うこと）
 - Docker Compose 設定
 - API ドキュメント生成
+- PR テンプレートへの TDD 証跡追加
 
-### 人間による手動レビュー必須（バイブコーディング適性：低〜中）
-- JWT 検証ミドルウェアやセキュリティ関連ロジック
+### 人間による手動レビュー必須（適性：低〜中）
+- JWT 検証ミドルウェア・セキュリティ関連ロジック
 - 暗号化・ハッシュ処理の実装
-- Postfix/Dovecot/Rspamd 等のインフラ・セキュリティ設定
+- Postfix/Dovecot/Rspamd 設定
 - Garage / OCI Object Storage アダプタ境界の実装
-- 本番セキュリティ設定、インフラ権限設計
+- 本番セキュリティ設定・インフラ権限設計
+- DB スキーマ破壊的変更 (Zero-downtime: gh-ost を使用)
 
-## 8. 仕様書リンク集
-- [PoC/Beta スコープ定義](https://github.com/willen-federation/recerdo-developers-docs/blob/main/docs/core/poc-beta-scope.md)
+### エスカレーション必須（独断禁止）
+
+以下の場合は新規 Issue を起票してバックログとし、実装をスキップすること:
+- アーキテクチャの根本的変更（DB スキーマの破壊的変更）
+- 仕様が曖昧で複数の設計方針が考えられる場合
+- 既存のビジネスロジックと著しく矛盾する修正が必要な場合
+
+---
+
+## 9. 重要なオーケストレーター決定事項 (2026-04-20)
+
+| 決定事項 | 内容 |
+|---|---|
+| Android リポジトリ | `recerdo-android-dart` → `recerdo-android` (Kotlin + Jetpack Compose) |
+| JWT 保存戦略 | Cognito Hosted UI 制約により **localStorage** 基本方針 |
+| カバレッジ閾値 | **80%** に統一 (旧: 60%) |
+| admin-system Phase1 | **Next.js 15 + shadcn/ui** (Rails は Phase3) |
+| DB バージョン | **MariaDB 10.11** 互換 (旧: 10.6) |
+| TDD プロセス | Red log + Green log + Coverage の 3 点証跡が全 PR に必須 |
+
+---
+
+## 10. 仕様書リンク集
+
+| ドキュメント | URL |
+|---|---|
+| PoC/Beta スコープ定義 | [poc-beta-scope.md](core/poc-beta-scope.md) |
+| 基本的方針 (ポリシー) | [policy.md](core/policy.md) |
+| 開発ワークフロー | [workflow.md](core/workflow.md) |
+| TDD Red→Green プロセス | [tdd-process.md](core/tdd-process.md) |
+| リポジトリ構成 (Gap Analysis) | [repo-inventory.md](core/repo-inventory.md) |
+| タスク依存関係マトリクス | [task-dependency-matrix.md](core/task-dependency-matrix.md) |
+| Bootstrap チェックリスト | [bootstrap-checklist.md](core/bootstrap-checklist.md) |
+| API Gateway 設計 | [api-gateway-design.md](core/api-gateway-design.md) |
+| Beta QA チェックリスト | [beta-qa-checklist.md](core/beta-qa-checklist.md) |
+| セキュリティ監査チェックリスト | [security-audit-checklist.md](core/security-audit-checklist.md) |
+| マイクロサービス設計 | [microservice/index.md](microservice/index.md) |
+| クリーンアーキテクチャ設計 | [clean-architecture/index.md](clean-architecture/index.md) |
+
+---
+
+最終更新: 2026-04-22 (v2.0 — オーケストレーター決定 2026-04-20 反映)

--- a/docs/core/tdd-process.md
+++ b/docs/core/tdd-process.md
@@ -1,0 +1,364 @@
+# TDD Red→Green プロセス
+
+> **ステータス**: Accepted  
+> **版**: v1.0 (2026-04-22)  
+> **適用範囲**: Willen-Federation org 配下の Recerdo 関連全リポジトリ  
+> **出典**: [Issue #41](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/41), オーケストレーター決定 (2026-04-20)
+
+---
+
+## 1. 概要
+
+Recerdo プロジェクトでは **Test-Driven Development (TDD)** を全 PR の必須プロセスとして採用する。  
+「テストが PASS した」だけでは不十分 — **失敗 (Red) → 実装 (Green) → リファクタ (Refactor)** の証跡が全 PR に必須となる。
+
+### なぜ TDD を強制するか
+
+1. **AIエージェントの虚偽 Done 防止**: `go test ./... | grep PASS` のみで Done 判定される「動作していないのにパスを出す」リスクを排除する
+2. **空テスト・スキップテストのゼロ tolerance**: 実際に動作を検証しないテストコードの混入を構造的に防ぐ
+3. **カバレッジの意味的保証**: 数値達成ではなく「意味のある検証」を強制する
+
+---
+
+## 2. Red-Green-Refactor の 3 ステップ
+
+```
+Step 1: RED (先行テスト実装)
+  ├── 実装コードを書く前にテストを書く
+  ├── go test ./... を実行
+  ├── FAIL ログを確認・記録
+  └── GitHub Actions パーマリンクを取得
+
+Step 2: GREEN (実装 → テスト通過)
+  ├── テストを通過させる最小限の実装を行う
+  ├── go test ./... を再実行
+  ├── PASS ログ + カバレッジを確認・記録
+  └── coverage ≥ 80% を確認 (line + branch)
+
+Step 3: REFACTOR (リファクタリング)
+  ├── コードをクリーンにする
+  ├── テストを再実行し PASS を維持
+  └── PR に Red ログ / Green ログ / Coverage レポートを添付
+```
+
+### 2.1 Bootstrap / 新規実装の場合
+
+新規リポジトリ立ち上げ (Bootstrap Issue) では、修正前の Red ログが存在しない場合がある。  
+その場合は PR に以下を明記すること:
+
+```
+Red log: N/A - 新規実装（修正前の失敗ログは存在しない）
+```
+
+---
+
+## 3. PR テンプレートへの TDD 証跡添付義務
+
+全 PR に以下セクションを含めること。テンプレートは各リポジトリの `.github/PULL_REQUEST_TEMPLATE.md` に設定される。
+
+```markdown
+## TDD 証跡（必須）
+
+### Red log（修正前: 失敗確認）
+<details><summary>失敗ログを貼付</summary>
+
+\`\`\`
+（該当テストが `FAIL` したログを貼付。Bootstrap 系 Issue は `N/A - 新規実装` と明記）
+\`\`\`
+</details>
+
+### Green log（修正後: 成功確認）
+<details><summary>成功ログを貼付</summary>
+
+\`\`\`
+（`PASS` + カバレッジ値を貼付）
+\`\`\`
+</details>
+
+### Coverage
+- Line coverage: __%（閾値: ≥ 80%）
+- Branch coverage: __%（閾値: ≥ 70%）
+```
+
+### 3.1 CI による PR テンプレ必須フィールド検証
+
+GitHub Actions `pr-checklist.yml` により、PR body に以下のキーワードが含まれない場合は自動 reject する:
+
+| 必須要素 | 検出キーワード | 例外 |
+|---|---|---|
+| TDD証跡セクション | `## TDD 証跡` | なし |
+| Red log | `Red log` | なし |
+| Green log | `Green log` | なし |
+| Coverage | `Line coverage:` | なし |
+
+---
+
+## 4. 空テスト禁止ガード (CI)
+
+### 4.1 検出対象
+
+以下のパターンを CI で検出し、検出した場合は **CI fail** とする:
+
+#### Go
+```bash
+# 空のテスト関数 (body が空)
+grep -rEn 'func Test[A-Z][A-Za-z0-9_]*\(t \*testing\.T\) \{[[:space:]]*\}' ./...
+
+# t.Skip の無条件使用
+grep -rn 't\.Skip(' ./... | grep -v '// allow-skip:'
+
+# 恒真 assertion (assert(true) 等)
+grep -rEn 'assert\.True\(t,\s*true\)|assert\.Equal\(t,\s*true,\s*true\)' ./...
+```
+
+#### TypeScript / JavaScript
+```bash
+# it.skip / describe.skip / xit / xdescribe
+grep -rEn 'it\.skip|describe\.skip|xit\(|xdescribe\(' ./...
+
+# 恒真 assertion
+grep -rEn 'expect\(true\)\.toBe\(true\)|expect\(1\)\.toBe\(1\)' ./...
+```
+
+#### Swift
+```bash
+grep -rEn 'XCTSkip|func testDisabled_' ./...
+```
+
+#### Kotlin / Android
+```bash
+grep -rEn '@Ignore|assumeTrue\(false\)' ./...
+```
+
+### 4.2 例外の扱い
+
+どうしてもスキップが必要な場合:
+
+1. 別途 GitHub Issue を起票し、スキップ理由と再有効化条件を記録する
+2. スキップするテストのコメントに `// allow-skip: #<Issue番号>` を追記する
+3. PR レビュアーが Issue 番号の有効性を確認する
+
+### 4.3 CI スクリプト (detect-empty-tests.sh)
+
+スクリプトは `recerdo-infra/scripts/detect-empty-tests.sh` に配置される。  
+各リポジトリの `test.yml` に以下のステップを追加する:
+
+```yaml
+- name: Detect empty/skip tests
+  run: |
+    curl -fsSL https://raw.githubusercontent.com/Willen-Federation/recerdo-infra/main/scripts/detect-empty-tests.sh | bash
+  env:
+    REPO_LANGUAGE: go  # go / typescript / swift / kotlin
+```
+
+---
+
+## 5. カバレッジゲート
+
+### 5.1 言語別閾値
+
+| 言語 | ツール | Line Coverage 閾値 | Branch Coverage 閾値 |
+|---|---|---|---|
+| **Go** | `go test -coverprofile=coverage.out` | **≥ 80%** | **≥ 70%** |
+| **TypeScript / JS** | `vitest --coverage` (c8/istanbul) | **≥ 80%** | **≥ 70%** |
+| **Swift (iOS)** | `XCTest` + `xccov` | **≥ 80%** | — |
+| **Kotlin (Android)** | `./gradlew jacocoTestReport` | **≥ 80%** | **≥ 70%** |
+
+### 5.2 CI でのカバレッジ強制
+
+```yaml
+# coverage-gate.yml (抜粋)
+- name: Check Go coverage
+  run: |
+    go test -coverprofile=coverage.out ./...
+    COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+    echo "Coverage: ${COVERAGE}%"
+    if (( $(echo "$COVERAGE < 80" | bc -l) )); then
+      echo "❌ Coverage ${COVERAGE}% is below the required 80%"
+      exit 1
+    fi
+    echo "✅ Coverage ${COVERAGE}% meets the requirement"
+```
+
+### 5.3 カバレッジ閾値達成のための禁止行為
+
+以下の方法でカバレッジを「水増し」することを禁止する:
+
+- 実際のビジネスロジックを検証しない「dummy test」の追加
+- 常に true を返す assertion (`assert(true)`, `expect(1).toBe(1)`)
+- テスト対象のコードを coverage 除外 (`// nolint:testpackage` の乱用)
+- モック過剰利用による実装コードの未テスト化
+
+---
+
+## 6. ミューテーションテスト (週次)
+
+### 6.1 目的
+
+テストの品質を「mutation score」で評価する。  
+mutant が生き残る (surviving mutant) 率が高いテストは、実質的な検証を行っていない。
+
+### 6.2 ツール
+
+| 言語 | ツール | Surviving mutant 閾値 |
+|---|---|---|
+| Go | [go-mutesting](https://github.com/zimmski/go-mutesting) | **≤ 30%** |
+| TypeScript | [Stryker Mutator](https://stryker-mutator.io/) | **≤ 30%** |
+| Swift | [Muter](https://github.com/muter-mutation-testing/muter) | **≤ 30%** |
+
+### 6.3 週次スケジュール
+
+```yaml
+# mutation-test.yml
+on:
+  schedule:
+    - cron: '0 2 * * 1'  # 毎週月曜 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  mutation-test-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install go-mutesting
+        run: go install github.com/zimmski/go-mutesting/cmd/go-mutesting@latest
+      - name: Run mutation tests
+        run: |
+          go-mutesting ./... --output=json > mutation-report.json
+          SURVIVOR_RATE=$(jq '.survivorRate' mutation-report.json)
+          echo "Survivor rate: ${SURVIVOR_RATE}%"
+          if (( $(echo "$SURVIVOR_RATE > 30" | bc -l) )); then
+            echo "❌ Mutation test survivor rate ${SURVIVOR_RATE}% exceeds 30%"
+            exit 1
+          fi
+      - name: Upload mutation report
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report
+          path: mutation-report.json
+```
+
+---
+
+## 7. AI エージェント (Claude 等) への適用ルール
+
+本セクションは `docs/core/workflow.md §17 AI補助開発` と連動する。
+
+### 7.1 必須義務
+
+AIエージェントが PR を生成・提出する場合、以下を **必ず** 実行すること:
+
+1. **先行テスト**: 実装コードを書く前にテストを記述し、`FAIL` を確認する
+2. **Red ログ取得**: `go test ./...` (または相当コマンド) の FAIL 出力を PR body に記録する
+3. **実装後 Green 確認**: 実装後に同じテストが `PASS` することを確認し、ログを記録する
+4. **カバレッジ確認**: `go test -coverprofile=coverage.out ./...` を実行し、閾値 (≥ 80%) を確認する
+5. **異常系テスト**: ネットワーク断 / タイムアウト / DB 接続失敗等のエラーパスを必ずテストする
+
+### 7.2 禁止行為
+
+- Red ログなしで「テスト済み」と主張すること
+- `t.Skip()` や `it.skip()` を理由なく使用すること
+- 空のテスト関数を含む PR を提出すること
+- カバレッジ閾値を満たすために意味のない assertion を追加すること
+- `go test ./... | grep -c PASS` のみで Done 判定すること
+
+### 7.3 Bootstrap 系 Issue の特例
+
+新規リポジトリの初期セットアップ (Bootstrap) では `FAIL` 前状態が存在しないため:
+
+```markdown
+Red log: N/A - 新規実装
+理由: Bootstrap Issue のため修正前のコードが存在しない。
+最初のテスト実装から開始し、Green log と Coverage を添付する。
+```
+
+---
+
+## 8. 異常系テスト要件
+
+通常の Happy path に加え、以下の異常系シナリオを **全 Phase1 以降の Issue** でテストすること:
+
+### 8.1 ネットワーク障害 (toxiproxy)
+
+```go
+// toxiproxy を用いた DB 接続断テスト例
+func TestRepository_DBConnectionFailure(t *testing.T) {
+    proxy := toxiproxy.NewProxy("mysql", "localhost:13306", "localhost:3306")
+    proxy.AddToxic("down", toxiproxy.ToxicTypeDown, ...)
+    defer proxy.Delete()
+    
+    // 接続断時の Retry / fallback を検証
+    _, err := repo.FindByID(ctx, "test-id")
+    assert.Error(t, err)
+    assert.ErrorIs(t, err, ErrServiceUnavailable)
+}
+```
+
+### 8.2 タイムアウト
+
+```go
+// Context deadline exceeded のハンドリング検証
+func TestUseCase_ContextTimeout(t *testing.T) {
+    ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+    defer cancel()
+    time.Sleep(10 * time.Millisecond)
+    
+    _, err := useCase.Execute(ctx, input)
+    assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+```
+
+### 8.3 DB 競合・重複
+
+```go
+// Idempotency Key の重複エラー検証
+func TestRepository_DuplicateIdempotencyKey(t *testing.T) {
+    // 1回目: 正常挿入
+    err := repo.Insert(ctx, record)
+    assert.NoError(t, err)
+    
+    // 2回目: 同じ Idempotency Key で409
+    err = repo.Insert(ctx, record)
+    assert.ErrorIs(t, err, ErrDuplicateEntry)
+}
+```
+
+---
+
+## 9. 証跡の保存と参照
+
+### 9.1 GitHub Actions Artifacts
+
+CI の `test.yml` は以下を artifact として保存する:
+
+- `coverage.out` — Go カバレッジプロファイル
+- `coverage.html` — カバレッジ HTML レポート
+- `mutation-report.json` — 週次ミューテーションレポート
+
+### 9.2 PR Body への必須リンク
+
+PR body には以下の GitHub Actions パーマリンクを含めること:
+
+```markdown
+### CI Evidence Links
+- Red log: [Actions Run #XXXX](https://github.com/Willen-Federation/recerdo-xxx/actions/runs/XXXX) (FAIL)
+- Green log: [Actions Run #YYYY](https://github.com/Willen-Federation/recerdo-xxx/actions/runs/YYYY) (PASS)
+- Coverage: XX.X% - [Coverage Report](https://github.com/Willen-Federation/recerdo-xxx/actions/runs/YYYY/artifacts)
+```
+
+---
+
+## 参照
+
+- [workflow.md §7 テスト戦略](workflow.md#7-テスト戦略)
+- [workflow.md §16 QA](workflow.md#16-qa-品質監査)
+- [workflow.md §17 AI 補助開発](workflow.md#17-ai-補助開発-claude-等)
+- [policy.md §3.2 カバレッジ閾値](policy.md)
+- [Issue #41 — TDD Blocker](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/41)
+- [Kent Beck — Canon TDD](https://tidyfirst.substack.com/p/canon-tdd)
+- [go-mutesting](https://github.com/zimmski/go-mutesting)
+- [Stryker Mutator](https://stryker-mutator.io/)
+
+---
+
+最終更新: 2026-04-22

--- a/docs/core/workflow.md
+++ b/docs/core/workflow.md
@@ -308,13 +308,20 @@ Recerdo は **Scrum / Agile** で開発する。Sprint は原則 2 週間、Mile
 
 ### 16.1 自動 QA (CI 内)
 - 全 workflow green 必須
-- カバレッジ下限達成必須
+- カバレッジ下限達成必須 (**≥ 80% line coverage, ≥ 70% branch coverage**)
 - contract test (buf breaking) pass 必須
+- **空テスト検出 (`detect-empty-tests.sh`) PASS 必須** — 空テスト・スキップテストが0件であること
+- **PR body に Red log / Green log / Coverage の 3 点セット含有確認** (`pr-checklist.yml`)
+- ミューテーションテスト (週次 cron) の survivor 率 ≤ 30%
 
 ### 16.2 手動 QA (merge 前 / release 前)
 - **Release checklist** (`recerdo-infra/qa/release-checklist.md`) を消化
 - **対応エラー時**: デバッグ → fix → CI 再実行 → 全 green までループ
+  - 修正 PR には必ず**「修正前の失敗ログ」と「修正後の成功ログ」の両方を添付**する
+  - 両ログに同一テストケース名が含まれていることを CI で確認する
 - **自動編集ポリシー**: CI 失敗の自動修正は lint / fmt のみ許可。テスト / ロジックの自動修正は禁止 (人間 review 経由)
+
+> 詳細な TDD プロセス定義: [docs/core/tdd-process.md](tdd-process.md)
 
 ---
 
@@ -324,15 +331,33 @@ Recerdo は **Scrum / Agile** で開発する。Sprint は原則 2 週間、Mile
 - AI 生成と明示するため PR の body に `Generated with <tool>` を任意記載可
 - **AI による自動 rename / 大規模リファクタは事前に人間承認必須**
 
+### 17.1 TDD 義務 (AI エージェント向け)
+
+AIエージェント (Claude 等) が PR を生成する場合、以下を **必ず** 実行すること:
+
+1. **先行テスト実装** → 実装前にテストを書き、`FAIL` を確認・記録する
+2. **Red ログ取得** → GitHub Actions の失敗 Run URL を PR body に貼付する
+3. **実装後 Green 確認** → `PASS` + カバレッジを記録し、URL を PR body に貼付する
+4. **カバレッジ閾値達成** → line coverage ≥ 80%, branch coverage ≥ 70% を確認する
+5. **異常系テスト** → ネットワーク断 / タイムアウト / 重複 Key 等のエラーパスを必ずテストする
+
+**禁止行為**:
+- Red ログなしで「テスト済み」と主張すること
+- 空テスト・スキップテストを含む PR を提出すること
+- カバレッジ水増しのために意味のない assertion を追加すること
+
+> 詳細ルール: [docs/core/tdd-process.md §7 AI エージェントへの適用ルール](tdd-process.md#7-ai-エージェント-claude-等-への適用ルール)
+
 ---
 
 ## 参照
 
 - [ADR-0001 命名規約](adr/0001-naming-convention.md)
 - [Bootstrap Checklist](bootstrap-checklist.md) — 各リポの初期セットアップ
+- [TDD Red→Green プロセス](tdd-process.md)
 - [ProjectTrackerBoard](https://github.com/Willen-Federation/Recerdo-Developers-Docs/issues/21)
 - [Policy](policy.md)
 
 ---
 
-最終更新: 2026-04-20
+最終更新: 2026-04-22


### PR DESCRIPTION
This PR enforces the TDD Red-Green-Refactor process for all AI agents and developers.

Changes:
- Creates `docs/core/tdd-process.md` to formally document the Red-Green-Refactor requirements.
- Updates `docs/CLAUDE.md` to add AI-specific TDD obligations.
- Updates `docs/core/workflow.md` to incorporate the new CI/CD testing gates.

Fixes #41.