### PR TITLE
docs: env-config guide, release engineering, chaos game day, QA checklist, migration playbook

### DIFF
--- a/docs/core/database-migration-playbook.md
+++ b/docs/core/database-migration-playbook.md
@@ -1,16 +1,121 @@
 # Database Migration Playbook
 
-## 適用方針
-- 原則: forward-only migration
-- 小規模変更: 通常 migration
-- 大規模変更（大テーブル・ロック懸念）: online schema migration を使用
+**参照**: `workflow.md §11.2 Rollback` · `policy.md §3.1 MariaDB 10.11`  
+**最終更新**: 2026-04-24
 
-## Expand-Migrate-Contract
-1. Expand: 互換性を維持した追加
-2. Migrate: 新旧互換の読み書き
-3. Contract: 旧構造の削除
+---
 
-## 実施ガード
-- 互換期間を設定し、段階的に切替える。
-- 失敗時は即時ロールフォワード用修正を適用する。
-- MySQL / MariaDB 互換性検証を CI で実施する。
+## 1. 適用方針
+
+| 規模 | 手法 |
+|---|---|
+| 小変更 (< 100 万行 / ロックなし) | 通常 Flyway migration |
+| 大変更 (≥ 100 万行 or ALTER TABLE ロック) | `gh-ost` (トリガーレス無停止) |
+
+**原則**: forward-only migration。ロールバック = forward 修正 PR。
+
+---
+
+## 2. Expand-Migrate-Contract パターン
+
+### Step 1 — Expand（カラム追加）
+```sql
+-- NULL 許容で追加（既存行に影響なし）
+ALTER TABLE users ADD COLUMN display_name VARCHAR(255) NULL;
+```
+CI: MySQL 8.0 + MariaDB 10.11 両方で PASS を確認。
+
+### Step 2 — Migrate（新旧両対応アプリをデプロイ）
+- アプリは旧カラムと新カラム両方を読み書き
+- バックグラウンドジョブで既存行をバックフィル
+
+### Step 3 — Contract（旧カラム削除）
+```sql
+-- 全行が新カラムに移行済みであることを確認してから実行
+ALTER TABLE users DROP COLUMN name;
+```
+
+各 Step を独立 PR で管理（PR 間に最低 1 スプリント間隔推奨）。
+
+---
+
+## 3. gh-ost による無停止大規模変更
+
+### 3.1 前提条件
+
+- `log-bin=mysql-bin` 有効
+- `binlog-format=ROW`
+- `log-slave-updates=ON`
+
+> ⚠️ MariaDB 10.11 での動作は個別検証が必要 (gh-ost は MySQL 向け設計)。  
+> MariaDB では `pt-online-schema-change` (Percona Toolkit) を代替として検討する。
+
+### 3.2 実行手順
+
+```bash
+# 1. Dry run（実際のコピーは行わない）
+gh-ost \
+  --host=localhost --port=3306 \
+  --user=root --password="$DB_PASSWORD" \
+  --database=recerdo --table=media_files \
+  --alter="ADD COLUMN thumbnail_path VARCHAR(512) NULL" \
+  --dry-run
+
+# 2. 本番実行
+gh-ost \
+  --host=localhost --port=3306 \
+  --user=root --password="$DB_PASSWORD" \
+  --database=recerdo --table=media_files \
+  --alter="ADD COLUMN thumbnail_path VARCHAR(512) NULL" \
+  --allow-on-master \
+  --max-load=Threads_running=25 \
+  --critical-load=Threads_running=100 \
+  --chunk-size=1000 \
+  --max-lag-millis=1500 \
+  --initially-drop-old-table \
+  --initially-drop-ghost-table \
+  --ok-to-drop-table \
+  --execute
+```
+
+### 3.3 進捗確認
+
+```bash
+echo "status" | nc -U /tmp/gh-ost.recerdo.media_files.sock
+```
+
+---
+
+## 4. CI 互換性確認
+
+```yaml
+strategy:
+  matrix:
+    db: [mysql:8.0, mariadb:10.11]
+services:
+  db:
+    image: ${{ matrix.db }}
+    env:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: recerdo_test
+```
+
+マイグレーションは両バージョンで PASS が必須 (policy.md §3.1)。
+
+---
+
+## 5. ロールバック手順
+
+DB migration は **forward-only**。ロールバック手順:
+
+1. Expand 済みカラムを残したまま旧アプリにロールバック（アプリのみ）
+2. 新カラムは NULL 許容のため旧アプリが無視しても問題なし
+3. 次 PR で旧カラム復元 or 新カラム削除の forward migration を適用
+
+---
+
+## 6. 参考
+
+- [gh-ost GitHub](https://github.com/github/gh-ost)
+- [Percona pt-online-schema-change](https://docs.percona.com/percona-toolkit/pt-online-schema-change.html)
+- [Stripe: Zero-downtime migrations](https://stripe.com/blog/online-migrations)

--- a/docs/core/env-config-guide.md
+++ b/docs/core/env-config-guide.md
@@ -1,0 +1,181 @@
+# Beta/Prod 環境設定ガイド
+
+**参照**: `policy.md §4.1 (12-factor)` · `environment-abstraction.md §3.2, §4.1, §8`  
+**最終更新**: 2026-04-24
+
+---
+
+## 1. 原則
+
+- 全環境で **同一 OCI Image (同一 SHA)** を使用
+- 差異は **環境変数のみ** で吸収（12-Factor App §3）
+- `STORAGE_PROVIDER=aws-s3` / `QUEUE_PROVIDER=aws-sqs` / `MAIL_PROVIDER=aws-ses` は**禁止**（CI grep で検出）
+
+---
+
+## 2. 環境変数カタログ
+
+### 2.1 インフラ切替（Feature Flag と対応）
+
+| 変数名 | Beta 値 | Prod 値 | Flipt フラグ |
+|---|---|---|---|
+| `STORAGE_PROVIDER` | `garage` | `oci-oss` | `infra.storage.provider` |
+| `QUEUE_PROVIDER` | `redis-bullmq` | `oci-queue` | `infra.queue.provider` |
+| `MAIL_PROVIDER` | `postfix-smtp` | `postfix-smtp` | `infra.mail.provider` |
+| `DB_HOST` | `mysql` (compose) | OCI MySQL FQDN | — |
+| `REDIS_HOST` | `redis` (compose) | OCI Redis FQDN | — |
+
+### 2.2 認証
+
+| 変数名 | 説明 |
+|---|---|
+| `COGNITO_USER_POOL_ID` | Cognito ユーザープール ID |
+| `COGNITO_CLIENT_ID` | Cognito アプリクライアント ID |
+| `COGNITO_JWKS_URI` | `https://cognito-idp.{region}.amazonaws.com/{pool}/.well-known/jwks.json` |
+| `JWT_EXPIRY_SEC` | アクセストークン有効秒（デフォルト: 3600） |
+
+### 2.3 ストレージ
+
+| 変数名 | Beta 値 | Prod 値 |
+|---|---|---|
+| `GARAGE_ENDPOINT` | `http://garage:3900` | — |
+| `OCI_NAMESPACE` | — | OCI Object Storage namespace |
+| `OCI_BUCKET_MEDIA` | — | OCI バケット名 |
+| `PRESIGNED_URL_TTL_SEC` | `3600` | `3600` |
+
+### 2.4 メール (Postfix STARTTLS)
+
+| 変数名 | 値 |
+|---|---|
+| `SMTP_HOST` | Postfix ホスト |
+| `SMTP_PORT` | `587` (Submission) |
+| `SMTP_TLS_MODE` | `starttls` (必須) |
+| `SMTP_FROM` | `noreply@recerdo.app` |
+
+### 2.5 Saga タイムアウト
+
+| 変数名 | デフォルト | 説明 |
+|---|---|---|
+| `SAGA_TIMEOUT_SEC` | `600` | Saga 全体 SLA 10 分 (policy.md §8.6) |
+| `OUTBOX_MAX_RETRY` | `3` | 3 回失敗で `DEAD` |
+| `OUTBOX_POLL_INTERVAL_MS` | `5000` | Outbox ポーリング間隔 |
+
+---
+
+## 3. .env.example ファイル規約
+
+各リポジトリのルートに以下 2 ファイルを配置する:
+
+```
+envs/
+  beta.env.example    # Beta (XServer VPS / k3s) 用
+  prod.env.example    # Prod (OCI) 用
+```
+
+### envs/beta.env.example テンプレート
+
+```env
+# === Infra ===
+STORAGE_PROVIDER=garage
+QUEUE_PROVIDER=redis-bullmq
+MAIL_PROVIDER=postfix-smtp
+
+# === Database ===
+DB_HOST=mysql
+DB_PORT=3306
+DB_NAME=recerdo
+DB_USER=recerdo
+DB_PASSWORD=CHANGE_ME
+
+# === Redis ===
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# === Cognito ===
+COGNITO_USER_POOL_ID=ap-northeast-1_XXXXXXXXX
+COGNITO_CLIENT_ID=XXXXXXXXXX
+COGNITO_JWKS_URI=https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_XXXXXXXXX/.well-known/jwks.json
+
+# === Garage (Beta S3-compatible) ===
+GARAGE_ENDPOINT=http://garage:3900
+GARAGE_ACCESS_KEY=CHANGE_ME
+GARAGE_SECRET_KEY=CHANGE_ME
+
+# === Saga ===
+SAGA_TIMEOUT_SEC=600
+OUTBOX_MAX_RETRY=3
+OUTBOX_POLL_INTERVAL_MS=5000
+
+# === SMTP ===
+SMTP_HOST=localhost
+SMTP_PORT=587
+SMTP_TLS_MODE=starttls
+SMTP_FROM=noreply@recerdo.app
+SMTP_USER=CHANGE_ME
+SMTP_PASSWORD=CHANGE_ME
+```
+
+---
+
+## 4. Feature Flag 初期投入
+
+`recerdo-infra/scripts/flipt-init.sh` で以下フラグを Flipt に登録する:
+
+```bash
+# scripts/flipt-init.sh 参照
+infra.queue.provider        # beta: redis-bullmq / prod: oci-queue
+infra.storage.provider      # beta: garage       / prod: oci-oss
+infra.mail.provider         # beta: postfix-smtp / prod: postfix-smtp
+infra.queue.killswitch      # kill switch: OFF
+infra.dualWrite.enabled     # dual write: OFF (移行期のみ ON)
+INFRA_BETA_K3S_ENABLED      # k3s モード: false
+```
+
+実行:
+```bash
+cd recerdo-infra
+bash scripts/flipt-init.sh http://localhost:8080
+```
+
+---
+
+## 5. 禁止キーワード CI チェック
+
+`.github/workflows/security.yml` に以下 grep ルールを追加済み:
+
+```yaml
+- name: Prohibited provider keywords
+  run: |
+    ! grep -rE 'STORAGE_PROVIDER=aws-s3|QUEUE_PROVIDER=aws-sqs|MAIL_PROVIDER=aws-ses' \
+      envs/ .env* 2>/dev/null \
+      || (echo "ERROR: prohibited AWS provider found" && exit 1)
+```
+
+---
+
+## 6. SMTP STARTTLS 確認コマンド
+
+```bash
+# TLS 1.2+ で接続確認
+openssl s_client -starttls smtp -connect <SMTP_HOST>:587 -brief
+
+# 期待出力: Protocol: TLSv1.2 or TLSv1.3
+# setup-mail-server.sh で smtpd_tls_security_level=encrypt を確認済み
+```
+
+---
+
+## 7. MariaDB 10.11 CI Matrix
+
+全バックエンドリポジトリの `test.yml` に以下 matrix を設定:
+
+```yaml
+strategy:
+  matrix:
+    db-version: [mysql:8.0, mariadb:10.11]
+services:
+  db:
+    image: ${{ matrix.db-version }}
+```
+
+`ci-templates/test.yml` を参照して全リポジトリに適用する (policy.md §3.1)。

--- a/docs/core/release-engineering.md
+++ b/docs/core/release-engineering.md
@@ -1,0 +1,152 @@
+# リリースエンジニアリング自動化
+
+**参照**: `environment-abstraction.md §8.1` · `policy.md §8.9 SLI/SLO` · `workflow.md §10, §12`  
+**最終更新**: 2026-04-24
+
+---
+
+## 1. カナリアデプロイ ステップ定義
+
+設定ファイル: `recerdo-infra/deploy/rollout-config.yaml`
+
+| ステップ | トラフィック比率 | 最小滞留時間 | 昇格条件 | 自動ロールバック条件 |
+|---|---|---|---|---|
+| canary-5 | 5% | 15 分 | 5xx < 0.1% かつ p95 < SLO | 5xx > 0.5% (5 分間) |
+| canary-20 | 20% | 30 分 | 5xx < 0.1% かつ p95 < SLO | 5xx > 0.5% (5 分間) |
+| canary-50 | 50% | 30 分 | 5xx < 0.1% かつ p95 < SLO | 5xx > 0.5% (5 分間) |
+| full | 100% | — | — | 5xx > 1.0% (5 分間) |
+
+SLO 閾値 (policy.md §8.9):
+
+| エンドポイント | p95 SLO |
+|---|---|
+| `GET /api/users/me/timeline` | < 500ms |
+| `POST /api/media/presigned-url` | < 2s |
+| JWKS 検証 | p99 < 50ms |
+
+---
+
+## 2. 自動ロールバック (`scripts/canary-judge.sh`)
+
+```bash
+# 使用例
+bash scripts/canary-judge.sh --step canary-5 --duration 900 --threshold 0.5
+# 0 = 昇格可, 1 = ロールバック要
+```
+
+**判定ロジック**:
+1. Prometheus から `rate(http_requests_total{status=~"5.."}[5m])` を取得
+2. エラー率 > `--threshold` % が `--duration` 秒継続 → exit 1 (ロールバック)
+3. 滞留時間経過後にエラー率正常 → exit 0 (昇格)
+
+Flipt ramp-up:
+```bash
+bash scripts/flipt-ramp.sh --flag feature.xxx --percentage 20
+```
+
+---
+
+## 3. エラーバジェット枯渔時 Release Freeze
+
+**Prometheus Recording Rule** (recerdo-infra/observability/):
+
+```yaml
+# 30 日ウィンドウ エラーバジェット消費率
+- record: job:error_budget_consumed:ratio
+  expr: |
+    1 - (
+      sum(rate(http_requests_total{status!~"5.."}[30d]))
+      / sum(rate(http_requests_total[30d]))
+    )
+```
+
+**Freeze 発動条件**: `job:error_budget_consumed:ratio > 0.20` (20% 消費)
+
+GitHub Actions での Freeze 制御:
+
+```yaml
+# deploy-beta.yml / deploy-prod.yml 冒頭
+- name: Check error budget
+  id: budget
+  run: |
+    BUDGET=$(curl -sf "$PROMETHEUS_URL/api/v1/query?query=job:error_budget_consumed:ratio" \
+      | jq -r '.data.result[0].value[1]')
+    echo "budget=$BUDGET" >> $GITHUB_OUTPUT
+    
+- name: Freeze check
+  if: |
+    steps.budget.outputs.budget > 0.20 &&
+    !contains(github.event.pull_request.labels.*.name, 'priority:P0') &&
+    !contains(github.event.pull_request.labels.*.name, 'type:security')
+  run: |
+    echo "Release Freeze: error budget consumed > 20%"
+    exit 1
+```
+
+Slack 通知 (Freeze 発動 / 解除):
+```bash
+curl -X POST "$SLACK_WEBHOOK" \
+  -d '{"text":"🚨 Release Freeze: error budget consumed > 20%. P0/security only."}'
+```
+
+---
+
+## 4. Flipt パーセンテージ ランプアップ (`scripts/flipt-ramp.sh`)
+
+```bash
+#!/bin/bash
+# Usage: bash scripts/flipt-ramp.sh --flag <key> --percentage <0-100>
+FLIPT_URL="${FLIPT_URL:-http://localhost:8080}"
+# ...flagのrollout ruleをPATCHする
+curl -X PUT "$FLIPT_URL/api/v1/flags/$FLAG/rules/$RULE_ID" \
+  -H "Content-Type: application/json" \
+  -d "{\"percentage\": $PERCENTAGE}"
+```
+
+Grafana Annotation を記録（根本原因調査用）:
+```bash
+curl -X POST "http://grafana:3000/api/annotations" \
+  -H "Content-Type: application/json" \
+  -d "{\"text\":\"Rollout $FLAG to ${PERCENTAGE}%\",\"tags\":[\"deploy\",\"$FLAG\"]}"
+```
+
+---
+
+## 5. リリースノート自動生成
+
+採用ツール: **`release-please`** (Google OSS、Go/TS/Rust 対応)
+
+```yaml
+# .github/workflows/release.yml
+- uses: google-github-actions/release-please-action@v4
+  with:
+    release-type: go  # or node, simple
+    config-file: release-please-config.json
+```
+
+`release-please-config.json` (recerdo-infra 参照) でコミットプレフィックス → CHANGELOG セクション対応。
+
+---
+
+## 6. Beta → 本番パイプライン
+
+```
+Beta (k3s / XServer VPS)
+  ↓ make beta-deploy VERSION=v1.2.3
+  ↓ canary-judge.sh 5% → 20% → 50% → 100%
+  ↓ (success) promote manifest to prod overlay
+
+Prod (OCI Container Instances)
+  ↓ same rollout-config.yaml
+  ↓ same canary-judge.sh logic
+  ↓ same OCI Image SHA (no rebuild)
+```
+
+**同一 Image SHA の CI 検証**:
+```yaml
+- name: Verify image SHA consistency
+  run: |
+    BETA_SHA=$(docker inspect ghcr.io/willen-federation/$SVC:$VERSION --format '{{.Id}}')
+    PROD_SHA=$(docker inspect ghcr.io/willen-federation/$SVC:$VERSION --format '{{.Id}}')
+    [ "$BETA_SHA" = "$PROD_SHA" ] || (echo "Image SHA mismatch" && exit 1)
+```

--- a/docs/microservice/call-matrix.md
+++ b/docs/microservice/call-matrix.md
@@ -1,16 +1,80 @@
 # サービス間呼び出し 同期/非同期マトリクス
 
-| 呼び出し元 | 呼び出し先 | 方式 | 同期/非同期 | 判断理由 |
-|---|---|---|---|---|
-| client | api-gateway | HTTP | 同期 | ユーザー応答を即時返却する必要がある |
-| api-gateway | permission-svc | gRPC | 同期 | 認可結果がないと処理継続できない |
-| api-gateway | storage-svc (presigned-url) | gRPC | 同期 | 署名 URL を即時返す必要がある |
-| storage-svc | queue-port | Outbox Event | 非同期 | 変換処理はバックグラウンド実行 |
-| media-transcoder | storage-svc | Event/Worker | 非同期 | CPU 高負荷処理のため分離 |
-| album-svc | timeline-svc | Domain Event | 非同期 | Saga Choreography で連携 |
-| album-svc | notifications-svc | Domain Event | 非同期 | 通知は遅延許容の非同期処理 |
-| 全サービス | audit-svc | Audit Event | 非同期 | 監査は補助経路で業務処理をブロックしない |
+**参照**: `policy.md §4.2, §8.5, §8.6, §8.9` · `environment-abstraction.md §4.3`  
+**最終更新**: 2026-04-24
 
 ## 判断基準
-- 同期: ユーザー応答・認可判定など、処理継続に即時結果が必要。
-- 非同期: 受付完了後に遅延実行できる処理（Outbox 経由）。
+
+| 基準 | 同期 gRPC | 非同期 Outbox |
+|---|---|---|
+| ユーザー応答待ち | ✅ | ❌ |
+| 認可/認証判定 | ✅ | ❌ |
+| 長時間処理 (>1s) | ❌ | ✅ |
+| Saga Choreography | ❌ | ✅ |
+| 監査・ログ (auxiliary path) | ❌ | ✅ |
+
+## 主要呼び出しマトリクス
+
+| 呼び出し元 | 呼び出し先 | 方式 | 同期/非同期 | SLO | 判断理由 |
+|---|---|---|---|---|---|
+| client | api-gateway | HTTP/REST | 同期 | p99 < 500ms | ユーザー応答を即時返却 |
+| api-gateway | permission-svc | gRPC | 同期 | p99 < 50ms | 認可結果がないと処理継続できない |
+| api-gateway | core-svc | gRPC | 同期 | p99 < 200ms | ユーザー操作応答 |
+| api-gateway | event-svc | gRPC | 同期 | p99 < 200ms | イベント作成応答 |
+| api-gateway | storage-svc (presigned-url) | gRPC | 同期 | p99 < 100ms | 署名 URL を即時返す |
+| api-gateway | feature-flag-svc | gRPC | 同期 | p99 < 30ms | フラグ評価 |
+| storage-svc | queue-port | Outbox Event | 非同期 | 60s SLO | MediaUploaded Saga §8.5 |
+| media-transcoder ← Outbox | storage-svc | Worker | 非同期 | 数分 | HLS/HEIC 変換、CPU高負荷 |
+| timeline-svc ← event-svc | event-subscription | Outbox | 非同期 | 5s SLO | Saga Choreography §8.6 |
+| album-svc ← storage-svc | event-subscription | Outbox | 非同期 | 60s SLO | MemoryPublished Saga §8.6 |
+| notifications-svc ← album-svc | event-subscription | Outbox | 非同期 | 60s SLO | Push通知 §8.9 |
+| notifications-svc ← event-svc | event-subscription | Outbox | 非同期 | 60s SLO | イベント招待通知 |
+| audit-svc ← 全svc | AuditEvent | Outbox | 非同期 | best-effort | 監査は auxiliary path §4.3 |
+| admin-system → core-svc | gRPC | 同期 | p99 < 500ms | 管理操作応答 |
+| admin-system → audit-svc | gRPC | 同期 | p99 < 200ms | 監査ログ即時取得 |
+
+## Saga フロー詳細 (§8.6)
+
+### MediaUpload Saga
+```
+Client → api-gateway → storage-svc (gRPC 同期)
+  → storage-svc publishes MediaUploaded (Outbox)
+    → media-transcoder: HLS/HEIC 変換
+    → album-svc: AlbumEntry 作成
+    → notifications-svc: push 通知
+    → audit-svc: UploadAction ログ
+```
+
+### EventCreation Saga
+```
+Client → api-gateway → event-svc (gRPC 同期)
+  → event-svc publishes EventCreated (Outbox)
+    → timeline-svc: フィード追加
+    → notifications-svc: 招待通知
+    → audit-svc: CreateEvent ログ
+```
+
+## Contract Test 戦略
+
+### Level 1 (実装済み): buf breaking
+Proto 破壊的変更を PR で自動検出。`.github/workflows/proto.yml` 参照。
+
+### Level 2 (推奨): Prism Mock
+```bash
+npx @stoplight/prism-cli mock docs/api/openapi-template.yaml --port 4010
+```
+Consumer 側 integration test で `localhost:4010` に向けて HTTP リクエストを送信。
+
+### Level 3 (M2 予定): Pact
+Consumer-Driven Contract Test。Consumer が Pact ファイルを生成し、Provider が検証。
+
+## Synthetic 監視 (本番)
+
+| チェック | 間隔 | アラート閾値 |
+|---|---|---|
+| `GET api.recerdo.app/health` | 30s | 2回連続失敗 |
+| `POST /api/v1/events` E2E | 5min | p99 > 2s |
+| `GET /api/v1/timeline` E2E | 5min | p99 > 1s |
+| Media upload → presigned → S3 | 15min | 失敗 |
+
+設定: Grafana Synthetic Monitoring (recerdo-infra observability stack)

--- a/docs/runbooks/chaos-game-day.md
+++ b/docs/runbooks/chaos-game-day.md
@@ -1,0 +1,115 @@
+# Chaos Engineering Game Day 計画
+
+**参照**: `policy.md §8.7 Circuit Breaker` · `environment-abstraction.md §8.2 緊急ロールバック`  
+**頻度**: 四半期に1回 (Beta M2 以降)
+
+---
+
+## ゴール
+
+本番類似環境 (staging VPS) で故意に障害を注入し、以下を検証する:
+
+1. Kill Switch・Circuit Breaker が期待通り動作するか
+2. Runbook 手順が実際に機能するか
+3. MTTR (Mean Time To Recover) の実測
+4. アラートが正しく発火するか
+
+---
+
+## シナリオ一覧
+
+### SEV1 シナリオ
+
+| ID | シナリオ | 注入方法 | 期待動作 | Kill Switch |
+|---|---|---|---|---|
+| C-01 | MySQL 完全停止 | `docker stop mysql` | api-gateway 503 返却, リトライ3回後断念 | `db.read_replica.enabled: OFF` |
+| C-02 | Redis 完全停止 | `docker stop redis` | セッションなし → Cognito フォールバック | `cache.session.enabled: OFF` |
+| C-03 | storage-svc 停止 | `docker stop recerdo-storage` | 画像アップロード503, 既存閲覧は継続 | `storage.upload.enabled: OFF` |
+
+### SEV2 シナリオ
+
+| ID | シナリオ | 注入方法 | 期待動作 |
+|---|---|---|---|
+| C-04 | Outbox Consumer 停止 | `kill -9 <outbox-worker-pid>` | メッセージ蓄積、再起動後追いつく |
+| C-05 | notifications-svc FCM 障害 | `iptables -A OUTPUT -p tcp --dport 443 -d fcm.googleapis.com -j DROP` | 通知失敗、5回リトライ後 DLQ |
+| C-06 | CPU/メモリ高負荷 | `stress --cpu 4 --vm 2 --vm-bytes 512M` | Rate limiter 発動、p99 増加 |
+
+### SEV3 シナリオ
+
+| ID | シナリオ | 注入方法 | 期待動作 |
+|---|---|---|---|
+| C-07 | network latency 500ms | `tc qdisc add dev eth0 root netem delay 500ms` | Circuit Breaker 発動 |
+| C-08 | packet loss 10% | `tc qdisc add dev eth0 root netem loss 10%` | 再試行増加、SLO 影響確認 |
+
+---
+
+## 実施手順
+
+### 準備 (前日)
+
+```bash
+# 1. staging 環境確認
+make beta-status
+
+# 2. 観測基盤確認
+curl -s http://localhost:3001/api/health  # Grafana
+
+# 3. Kill Switch デフォルト確認
+curl -s http://flipt:8080/api/v1/flags | jq '.flags[] | {key, enabled}'
+
+# 4. ロールバックコマンド確認
+make beta-rollback SVC=recerdo-storage VERSION=latest
+```
+
+### 実施 (Game Day 当日)
+
+```bash
+# 各シナリオ: 注入 → 観測 → 回復 → 記録
+# 例: C-01
+docker stop mysql
+# → Grafana で mysql_up = 0 確認
+# → api-gateway エラー率 確認
+# → Kill Switch 発動: flipt flag update db.read_replica.enabled false
+# → 回復: docker start mysql
+# → MTTR 記録
+```
+
+### 後処理
+
+```bash
+# tc ルール削除
+tc qdisc del dev eth0 root
+
+# iptables ルール削除
+iptables -D OUTPUT -p tcp --dport 443 -d fcm.googleapis.com -j DROP
+
+# Kill Switch リセット
+# 全フラグを元の状態に戻す
+```
+
+---
+
+## 合格基準 (SLO)
+
+| メトリクス | 目標 |
+|---|---|
+| MTTR (SEV1) | < 30 分 |
+| MTTR (SEV2) | < 2 時間 |
+| Kill Switch 発動 → 効果確認 | < 2 分 |
+| アラート発火遅延 | < 2 分 |
+| Runbook 手順完走率 | 100% |
+
+---
+
+## 結果記録テンプレート
+
+```markdown
+## Game Day YYYY-MM-DD
+
+| シナリオ | 開始 | 回復 | MTTR | Kill Switch 使用 | 問題点 |
+|---|---|---|---|---|---|
+| C-01 | HH:MM | HH:MM | MM 分 | はい/いいえ | |
+
+### アクションアイテム
+- [ ] ...
+```

--- a/docs/templates/post-mortem-template.md
+++ b/docs/templates/post-mortem-template.md
@@ -1,34 +1,96 @@
 # Post-Mortem Template
 
+> SEV1/SEV2 は解消後 48 時間以内に作成必須 (workflow.md §15.2)。  
+> エラーバジェットの 20% 以上消費した場合も作成。
+
+---
+
 ## 1. Summary
-- Incident ID:
-- Severity:
-- Start (UTC):
-- End (UTC):
-- Duration:
+
+| 項目 | 内容 |
+|---|---|
+| Incident ID | INC-YYYY-MMDD-NNN |
+| Severity | SEV1 / SEV2 / SEV3 |
+| 検知 (UTC) | YYYY-MM-DD HH:MM |
+| 解消 (UTC) | YYYY-MM-DD HH:MM |
+| Duration | HH 時間 MM 分 |
+| 担当 IC (Incident Commander) | |
+| 通知先 | Slack #incidents, 管理者 |
+
+---
 
 ## 2. Impact
-- 影響機能:
-- 影響ユーザー:
-- ビジネス影響:
+
+| 項目 | 内容 |
+|---|---|
+| 影響機能 | (例: 画像アップロード, タイムライン) |
+| 影響ユーザー数 | (例: 全ユーザー / 一部) |
+| エラー率ピーク | (例: 42%) |
+| エラーバジェット消費 | (例: 月次バジェットの XX%) |
+| ビジネス影響 | (例: アップロード不可, 通知遅延) |
+
+---
 
 ## 3. Timeline (UTC)
-- HH:MM 事象
-- HH:MM 対応
+
+| 時刻 | イベント |
+|---|---|
+| HH:MM | 異常検知 (アラート / ユーザー報告) |
+| HH:MM | IC 任命・インシデント宣言 |
+| HH:MM | 調査開始 |
+| HH:MM | 仮説 X を確認 |
+| HH:MM | Kill Switch / ロールバック 実施 |
+| HH:MM | ユーザー影響解消確認 |
+| HH:MM | 根本原因特定 |
+| HH:MM | インシデントクローズ |
+
+---
 
 ## 4. Root Cause
-- 直接原因:
-- 背景要因:
-- 5 Whys:
+
+### 直接原因
+(例: storage-svc の DB 接続プールが枯渇)
+
+### 5 Whys 分析
+
+1. なぜ障害が発生したか？
+2. なぜ (1) が起きたか？
+3. なぜ (2) が起きたか？
+4. なぜ (3) が起きたか？
+5. 根本要因:
+
+### 寄与要因
+- (例: 監視の閾値が不適切だった)
+- (例: Runbook が古かった)
+
+---
 
 ## 5. Trigger / Resolution
-- Trigger:
-- Resolution:
-- 再発防止:
+
+| 項目 | 内容 |
+|---|---|
+| Trigger | どの変更・イベントが引き金か |
+| Detection Method | アラート / ユーザー報告 / 監視 |
+| Resolution | 実施した対応 (Kill Switch, rollback, restart) |
+| Kill Switch 使用 | フラグ名 / ON→OFF |
+| 再発防止策 | |
+
+---
 
 ## 6. Action Items
-- [ ] P0: 担当 / 期限
-- [ ] P1: 担当 / 期限
 
-## 7. Blameless Review
-- 個人責任ではなく、仕組み改善に焦点を当てる。
+P0 アクションアイテムは最低 1 件必須 (Google SRE Error Budget Policy)。
+
+| Priority | Action | 担当 | 期限 |
+|---|---|---|---|
+| P0 | | | YYYY-MM-DD |
+| P1 | | | YYYY-MM-DD |
+| P2 | | | |
+
+---
+
+## 7. Blameless Review Policy
+
+> 「誰が悪いか」ではなく「なぜシステムが失敗を許したか」を問う。  
+> 個人の行動を責めず、プロセス・ツール・設計の改善に焦点を当てる。  
+> このドキュメントは公開される前提で作成すること。


### PR DESCRIPTION
## Summary
- `docs/core/env-config-guide.md` — 環境変数カタログ、Feature Flag 初期投入、禁止キーワード CI ルール (#37)
- `docs/core/release-engineering.md` — カナリアデプロイ、エラーバジェット Freeze、Flipt ランプアップ (#42)
- `docs/runbooks/chaos-game-day.md` — SEV1-3 シナリオ、実施手順、合格基準 (#43)
- `docs/templates/post-mortem-template.md` — Google SRE 形式 + 5 Whys + Blameless (#43)
- `docs/microservice/call-matrix.md` — SLO 追加、Saga フロー、Contract Test 戦略 (#44)
- `docs/core/database-migration-playbook.md` — gh-ost 手順、Expand-Migrate-Contract (#45)

## Test plan
- [ ] MkDocs build passes
- [ ] All referenced scripts exist in recerdo-infra

Closes #37 Closes #42 Closes #43 Closes #44 Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)